### PR TITLE
Update composer to pull in theme dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ tooling:
   - Runs on lando rebuild and installs  Node and NPM in your docker container, adds gulp and other packages and their dependencies to the 'node_modules' in /themes.contrib/prudentia directory.
   - Assumes your webroot folder name is "web". You might need to change it with "docroot" or with the name of your webroot folder. 
 
-- You need to install/enable **Components Library** Drupal module (https://www.drupal.org/project/components) to use the Prudentia components 
+- The Prudentia theme depends on the Components Library Drupal module (https://www.drupal.org/project/components) and the module must be enabled to enable the theme. If you install the theme via composer the module will be pulled into your codebase automatically.
+
 
 - This theme uses as reference the uswds-gulp repo to configure npm and gulp files.
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,7 @@ It uses GULP to compile SASS and copy USWDS assets.
 
 INSTALLATION
 ------------
-1. Install uswds_base theme 
-`lando composer require 'drupal/uswds_base:^2.4'`
-
-2. Install Prudentia theme
+1. Install Prudentia theme
 `lando composer require atf/prudentia`
 
 3. Copy the "**yourthemename**" folder from the "*/prudentia/starterkit*" dir to the "*themes/custom*" directory in your codebase.

--- a/composer.json
+++ b/composer.json
@@ -4,5 +4,8 @@
     "type": "drupal-theme",
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
-    "require": {}
+    "require": {
+        "drupal/uswds_base": "^2.4",
+        "drupal/components": "^2.2"
+    }
 }

--- a/prudentia.info.yml
+++ b/prudentia.info.yml
@@ -6,6 +6,8 @@ base theme: uswds_base
 package: 'USWDS Base'
 core: 8.x
 core_version_requirement: ^8 || ^9
+dependencies:
+  - drupal:components
 logo: 'logo.png'
 screenshot: 'screenshot.png'
 

--- a/prudentia.info.yml
+++ b/prudentia.info.yml
@@ -31,7 +31,7 @@ libraries:
   # if Prudentia is set as a theme default uncomment this
   #  - prudentia/assets
 
-component-libraries:
-  uswds:
-    paths:
-     - ../../contrib/prudentia/components
+components:
+  namespaces:
+    uswds:
+      - ../../contrib/prudentia/components

--- a/starterkit/yourthemename/yourthemename.info.rename.me.yml
+++ b/starterkit/yourthemename/yourthemename.info.rename.me.yml
@@ -27,12 +27,9 @@ regions:
 libraries:
   - 'yourthemename/assets'
 
-component-libraries:
-  uswds:
-    paths:
+components:
+  namespaces:
+    uswds:
      - ../../../themes/contrib/prudentia/components
-
-  yourthemename:
-    paths:
+    yourthemename:
      - components
-


### PR DESCRIPTION
This PR adds the components module and usdws_base to the composer file so that when `composer require atf/prudentia` is called, the base theme and components module will be pulled into their respective contrib folders without running additional commands. It also adds 'components' to the prudentia dependencies so that it needs to be turned on to enable the theme.